### PR TITLE
Rework preview modal

### DIFF
--- a/assets/css/acf-flexible-content-preview.css
+++ b/assets/css/acf-flexible-content-preview.css
@@ -3,14 +3,21 @@
   position: fixed !important;
   top: 50% !important;
   left: 50% !important;
-  width: 80%;
-  height: 80%;
+  width: 95%;
+  height: 88%;
   max-width: 1200px;
   max-height: 1200px;
   background: none !important;
   padding: 0;
   border-radius: 0;
   transform: translate(-50%, -50%);
+}
+
+@media only screen and (min-width: 783px) {
+  .acf-fc-popup .acf-fc-popup {
+    width: 80%;
+    height: 80%;
+  }
 }
 
 .acf-fc-popup * {
@@ -36,28 +43,30 @@
 }
 
 .acf-fc-popup ul {
+  display: flex;
+  flex-wrap: wrap;
+  align-content: center;
+  justify-content: space-around;
   position: relative;
   width: 100%;
   height: 100%;
   background: #f4f4f4;
-  padding: 15px;
+  padding: 10px 0;
   border: #ccc;
   box-shadow: 0 0 8px rgba(0, 0, 0, 0.5);
   overflow: auto;
 }
 
-.acf-fc-popup ul::after {
-  content: '';
-  display: block;
-  float: left;
-  width: 100%;
-  height: 10px;
+.acf-fc-popup ul li {
+  width: 264px;
+  max-width: 100%;
+  padding: 10px;
 }
 
-.acf-fc-popup ul li {
-  float: left;
-  width: calc(100% / 3);
-  padding: 1%;
+@media only screen and (min-width: 400px) {
+  .acf-fc-popup ul li {
+    width: 386px;
+  }
 }
 
 .acf-fc-popup ul li a {
@@ -91,24 +100,14 @@
 }
 
 .acf-fc-popup ul li a .acf-fc-popup-image {
-  height: 150px;
+  height: 100px;
   background-position: center !important;
   background-repeat: round !important;
   background-size: cover !important;
 }
 
-@media only screen and (max-width: 960px) {
-  .acf-fc-popup ul li {
-    width: 50%;
-  }
-}
-
-@media only screen and (max-width: 782px) {
-  .acf-fc-popup {
-    width: 95%;
-    height: 88%;
-  }
-  .acf-fc-popup ul li {
-    width: 100%;
+@media only screen and (min-width: 400px) {
+  .acf-fc-popup ul li a .acf-fc-popup-image {
+    height: 150px;
   }
 }

--- a/assets/css/acf-flexible-content-preview.css
+++ b/assets/css/acf-flexible-content-preview.css
@@ -5,7 +5,7 @@
   left: 50% !important;
   width: 95%;
   height: 88%;
-  max-width: 1200px;
+  max-width: 1400px;
   max-height: 1200px;
   background: none !important;
   padding: 0;
@@ -45,27 +45,38 @@
 .acf-fc-popup ul {
   display: flex;
   flex-wrap: wrap;
-  align-content: center;
-  justify-content: space-around;
+  justify-content: flex-start;
   position: relative;
   width: 100%;
   height: 100%;
   background: #f4f4f4;
-  padding: 10px 0;
+  padding: 15px;
   border: #ccc;
   box-shadow: 0 0 8px rgba(0, 0, 0, 0.5);
-  overflow: auto;
+  overflow-y: auto;
+}
+
+.acf-fc-popup ul::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 15px;
 }
 
 .acf-fc-popup ul li {
-  width: 264px;
-  max-width: 100%;
-  padding: 10px;
+  width: 100%;
+  padding: 15px;
 }
 
-@media only screen and (min-width: 400px) {
+@media only screen and (min-width: 600px) {
   .acf-fc-popup ul li {
-    width: 386px;
+    width: 50%;
+  }
+}
+
+@media only screen and (min-width: 1200px) {
+  .acf-fc-popup ul li {
+    width: calc(100% / 3);
   }
 }
 
@@ -100,14 +111,8 @@
 }
 
 .acf-fc-popup ul li a .acf-fc-popup-image {
-  height: 100px;
   background-position: center !important;
   background-repeat: round !important;
   background-size: cover !important;
-}
-
-@media only screen and (min-width: 400px) {
-  .acf-fc-popup ul li a .acf-fc-popup-image {
-    height: 150px;
-  }
+  padding-bottom: 41.67%;
 }

--- a/assets/scss/acf-flexible-content-preview.scss
+++ b/assets/scss/acf-flexible-content-preview.scss
@@ -5,7 +5,7 @@
   left: 50% !important;
   width: 95%;
   height: 88%;
-  max-width: 1200px;
+  max-width: 1400px;
   max-height: 1200px;
   background: none !important;
   padding: 0;
@@ -13,6 +13,7 @@
   transform: translate(-50%, -50%);
 
   @media only screen and (min-width: 783px) {
+
     .acf-fc-popup {
       width: 80%;
       height: 80%;
@@ -45,24 +46,33 @@
   ul {
     display: flex;
     flex-wrap: wrap;
-    align-content: center;
-    justify-content: space-around;
+    justify-content: flex-start;
     position: relative;
     width: 100%;
     height: 100%;
     background: #f4f4f4;
-    padding: 10px 0;
+    padding: 15px;
     border: #ccc;
     box-shadow: 0 0 8px rgba(#000, .5);
-    overflow: auto;
+    overflow-y: auto;
+
+    &::after {
+      content: '';
+      display: block;
+      width: 100%;
+      height: 15px;
+    }
 
     li {
-      width: 264px; // 244px wide image + 10px padding
-      max-width: 100%;
-      padding: 10px;
+      width: 100%;
+      padding: 15px;
 
-      @media only screen and (min-width: 400px) {
-        width: 386px; // 366px wide image + 10px padding
+      @media only screen and (min-width: 600px) {
+        width: 50%;
+      }
+
+      @media only screen and (min-width: 1200px) {
+        width: calc(100% / 3);
       }
 
       a {
@@ -97,14 +107,10 @@
         }
 
         .acf-fc-popup-image {
-          height: 100px;
           background-position: center !important;
           background-repeat: round !important;
           background-size: cover !important;
-
-          @media only screen and (min-width: 400px) {
-            height: 150px;
-          }
+          padding-bottom: 41.67%;
         }
       }
     }

--- a/assets/scss/acf-flexible-content-preview.scss
+++ b/assets/scss/acf-flexible-content-preview.scss
@@ -3,14 +3,21 @@
   position: fixed !important;
   top: 50% !important;
   left: 50% !important;
-  width: 80%;
-  height: 80%;
+  width: 95%;
+  height: 88%;
   max-width: 1200px;
   max-height: 1200px;
   background: none !important;
   padding: 0;
   border-radius: 0;
   transform: translate(-50%, -50%);
+
+  @media only screen and (min-width: 783px) {
+    .acf-fc-popup {
+      width: 80%;
+      height: 80%;
+    }
+  }
 
   * {
     box-sizing: border-box;
@@ -36,27 +43,27 @@
   }
 
   ul {
+    display: flex;
+    flex-wrap: wrap;
+    align-content: center;
+    justify-content: space-around;
     position: relative;
     width: 100%;
     height: 100%;
     background: #f4f4f4;
-    padding: 15px;
+    padding: 10px 0;
     border: #ccc;
     box-shadow: 0 0 8px rgba(#000, .5);
     overflow: auto;
 
-    &::after {
-      content: '';
-      display: block;
-      float: left;
-      width: 100%;
-      height: 10px;
-    }
-
     li {
-      float: left;
-      width: calc(100% / 3);
-      padding: 1%;
+      width: 264px; // 244px wide image + 10px padding
+      max-width: 100%;
+      padding: 10px;
+
+      @media only screen and (min-width: 400px) {
+        width: 386px; // 366px wide image + 10px padding
+      }
 
       a {
         padding: 0;
@@ -90,31 +97,16 @@
         }
 
         .acf-fc-popup-image {
-          height: 150px;
+          height: 100px;
           background-position: center !important;
           background-repeat: round !important;
           background-size: cover !important;
+
+          @media only screen and (min-width: 400px) {
+            height: 150px;
+          }
         }
       }
-    }
-  }
-}
-
-@media only screen and (max-width: 960px) {
-
-  .acf-fc-popup ul li {
-    width: 50%;
-  }
-}
-
-@media only screen and (max-width: 782px) {
-
-  .acf-fc-popup {
-    width: 95%;
-    height: 88%;
-
-    ul li {
-      width: 100%;
     }
   }
 }


### PR DESCRIPTION
Switches layout to centered (horizontally space-around) flexbox, and ensures images keep a consistent aspect ratio. Should look much nicer on small screens especially, where before they were getting stretched to 100% width. Still maxes out at 3 components wide.