### PR TITLE
Update hook for enqueuing and registering assets

### DIFF
--- a/classes/main.php
+++ b/classes/main.php
@@ -6,8 +6,8 @@ class Main {
 	protected function init() {
 
 		// Assets
-		add_action( 'acf/input/admin_footer', [ $this, 'register_assets' ], 1 );
-		add_action( 'acf/input/admin_footer', [ $this, 'enqueue_assets' ] );
+		add_action( 'admin_footer', [ $this, 'register_assets' ], 1 );
+		add_action( 'admin_footer', [ $this, 'enqueue_assets' ] );
 
 		// Images
 		add_action( 'acf/input/admin_footer', [ $this, 'layouts_images_style' ], 20 );


### PR DESCRIPTION
ACF 5.9 changes the way the admin system works with ACF. In order for this JS & CSS to actually enqueue, the hooks need to change.

<!--
Thanks for contributing !

Please note :
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards).
- In case you introduced a new action or filter hook, please also include [inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php).
- Please provide tests, if you can.
-->

This pull request fixes issue #9 

It will apply the following changes :

* Change the CSS and JS hooks to use standard WP admin hooks for enqueuing CSS/JS since ACF hooks no longer cause these to output the CSS/JS.
