### PR TITLE
Fix for gathering keys from nested fields

### DIFF
--- a/classes/main.php
+++ b/classes/main.php
@@ -6,7 +6,6 @@ class Main {
 	use Singleton;
 
 	protected function init() {
-
 		// Assets
 		add_action( 'acf/input/admin_enqueue_scripts', [ $this, 'register_assets' ], 1 );
 		add_action( 'acf/input/admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
@@ -66,7 +65,13 @@ class Main {
 	 */
 	protected function retrieve_flexible_keys_from_fields( $fields, &$keys ) {
 		foreach ( $fields as $field ) {
-			if ( 'flexible_content' === $field['type'] ) {
+			if ( 'repeater' === $field['type'] ) {
+				// If this is a repeater field, check to see if it
+				// contains any nested flexible content fields
+				$subFields = acf_get_fields($field);
+				$this->retrieve_flexible_keys_from_fields( $subFields, $keys );
+				
+			} elseif ( 'flexible_content' === $field['type'] ) {
 				foreach ( $field['layouts'] as $layout_field ) {
 					// Don't revisit keys we've recorded already
 					if ( ! empty( $keys[ $layout_field['key'] ] ) ) {


### PR DESCRIPTION
<!--
Thanks for contributing !

Please note :
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards).
- In case you introduced a new action or filter hook, please also include [inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php).
- Please provide tests, if you can.
-->

This addresses an issue found when a Flexible Content field is nested inside a Repeater.  The image thumbnails are missed in this scenario, resulting in blank cards for the various Flexible Content options.  

It will apply the following changes :
* a check for 'repeater' field types in the retrieve_flexible_keys_from_fields method
* a recursive call to retrieve_flexible_keys_from_fields if a 'repeater' field is encountered

