### PR TITLE
Applied images_path filter on default image & added specific hook for default image path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,17 @@ Transforms ACF's flexible content field's layout list into a modal with image pr
 ## Image Location
 
 Images should be placed in your theme. By default, images are located here: `THEME/lib/admin/images/acf-flexible-content-preview`.
+A file with name `default.jpg` can be placed here to overwrite the default grey image.
 
 Also note that you can filter this path, but it **MUST** be in your theme:
 
 `add_filter( 'acf-flexible-content-preview.images_path', $path );`
+
+You can also set a custom path for only the `default.jpg` image:
+
+`add_filter( 'acf-flexible-content-preview.default_path', $path );`
+
+Note that if you have already defined a custom images_path you can place your `default.jpg` at that location.
 
 **NOTE:** The path should not have a trailing beginning or trailing slash!
 

--- a/classes/main.php
+++ b/classes/main.php
@@ -142,6 +142,17 @@ class Main {
 			return $image_uri;
 		}
 
+		// Allow for setting custom "Default" image
+		$default_path = apply_filters( 'acf-flexible-content-preview.default_path', $path );
+
+		$default_image_path = get_stylesheet_directory() . '/' . $default_path . '/default.jpg';
+		$default_image_uri = get_stylesheet_directory_uri() . '/' . $default_path . '/default.jpg';
+
+		// Direct default path to custom folder
+		if ( is_file( $default_image_path ) ) {
+			return $default_image_uri;
+		}
+
 		return FCP_URL . 'assets/images/default.jpg';
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -23,10 +23,17 @@ Transforms ACF's flexible content field's layout list into a modal with image pr
 = Image Location =
 
 Images should be placed in your theme. Be fault, images are located here: `THEME/lib/admin/images/acf-flexible-content-preview`.
+A file with name `default.jpg` can be placed here to overwrite the default grey image.
 
 Also note that you can filter this path, but it **MUST** be in your theme:
 
 `add_filter( 'acf-flexible-content-preview.images_path', $path );`
+
+You can also set a custom path for only the `default.jpg` image:
+
+`add_filter( 'acf-flexible-content-preview.default_path', $path );`
+
+Note that if you have already defined a custom images_path you can place your `default.jpg` at that location.
 
 **NOTE:** The path should not have a trailing beginning or trailing slash!
 


### PR DESCRIPTION
Hi,

The `acf-flexible-content-preview.images_path` did not apply to the `default.jpg` image.
This was added so that people can set a custom default image with website logo for example.

A seperate hook was added to overwrite only the default image path.
It uses the path of the `acf-flexible-content-preview.images_path` to make the chain intact.

Also updated readme files accordingly.

Kind regards
Vinobe