### PR TITLE
resolve php 8 warning

### DIFF
--- a/classes/singleton.php
+++ b/classes/singleton.php
@@ -50,12 +50,12 @@ trait Singleton {
 	 *
 	 * @return void
 	 */
-	final private function __clone() {}
+	final public function __clone() {}
 
 	/**
 	 * prevent from being unserialized
 	 *
 	 * @return void
 	 */
-	final private function __wakeup() {}
+	final public function __wakeup() {}
 }


### PR DESCRIPTION
<!--
Thanks for contributing !

Please note :
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards).
- In case you introduced a new action or filter hook, please also include [inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php).
- Please provide tests, if you can.
-->

This pull request resolve php 8 Warnings.

Warnings :
* PHP Warning: Private methods cannot be final as they are never overridden by other classes in acf-flexible-content-preview/classes/singleton.php on line 53
* PHP Warning: Private methods cannot be final as they are never overridden by other classes in acf-flexible-content-preview/classes/singleton.php on line 60
* PHP Warning:  The magic method FCP\Singleton::__wakeup() must have public visibility in acf-flexible-content-preview/classes/singleton.php on line 60
