### PR TITLE
Fix PHP 8 warnings [#23]

### DIFF
--- a/classes/singleton.php
+++ b/classes/singleton.php
@@ -23,7 +23,7 @@ trait Singleton {
 	/**
 	 * @return self
 	 */
-	final public static function get_instance() {
+	public final static function get_instance() {
 		if ( is_null( self::$instance ) ) {
 			self::$instance = new static;
 		}
@@ -50,12 +50,12 @@ trait Singleton {
 	 *
 	 * @return void
 	 */
-	final private function __clone() {}
+	public final function __clone() {}
 
 	/**
 	 * prevent from being unserialized
 	 *
 	 * @return void
 	 */
-	private function __wakeup() {}
+	public final function __wakeup() {}
 }

--- a/classes/singleton.php
+++ b/classes/singleton.php
@@ -34,7 +34,7 @@ trait Singleton {
 	/**
 	 * Constructor protected from the outside
 	 */
-	final private function __construct() {
+	private function __construct() {
 		$this->init();
 	}
 
@@ -57,5 +57,5 @@ trait Singleton {
 	 *
 	 * @return void
 	 */
-	final private function __wakeup() {}
+	private function __wakeup() {}
 }


### PR DESCRIPTION
<!--
Thanks for contributing !

Please note :
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards).
- In case you introduced a new action or filter hook, please also include [inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php).
- Please provide tests, if you can.
-->

This pull request fixes issue #23 .

It will apply the following changes :

* Updates the singleton class to remove the word `final` from private methods
* Sets the `__wakeup` method to public
